### PR TITLE
Make Drowned drop Copper Ingots

### DIFF
--- a/src/main/resources/data/minecraft/loot_tables/entities/drowned.json
+++ b/src/main/resources/data/minecraft/loot_tables/entities/drowned.json
@@ -46,7 +46,7 @@
       "entries": [
         {
           "type": "minecraft:item",
-          "name": "minecraft:gold_ingot"
+          "name": "minecraft:copper_ingot"
         }
       ],
       "conditions": [


### PR DESCRIPTION
Changes the Drowned loot tables to have them drop Copper Ingots instead of Gold Ingots when killed by the player, in accordance to it being changed in 1.17.